### PR TITLE
Generate image set info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ verify-coverage:
 # Test tasks
 # ----------
 
-test: test-unit-coverage verify-coverage
+test: test-unit-coverage verify-coverage test-integration
 	@$(DONE)
 
 test-unit:
@@ -27,4 +27,8 @@ test-unit:
 
 test-unit-coverage:
 	@NODE_ENV=test nyc --reporter=text --reporter=html node_modules/.bin/_mocha test/unit --recursive
+	@$(DONE)
+
+test-integration:
+	@NODE_ENV=test mocha test/integration --recursive --timeout 10000 --slow 2000
 	@$(DONE)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,38 @@ npm install @financial-times/origami-image-set-tools
 
 ### Command-Line Interface
 
-This module exposes an `oist` command which doesn't do anything yet.
+This module exposes an `oist` command which can be used to manage image sets from the command line:
+
+```
+Usage: oist [options] [command]
+
+
+Commands:
+
+  build-manifest [options]   build an image set manifest file and save to "imageset.json"
+  *                          unrecognised commands will output this help page
+
+Options:
+
+  -h, --help     output usage information
+  -V, --version  output the version number
+```
+
+#### Build Manifest
+
+The `oist build-manifest` command creates a JSON manifest file detailing all of the images in the set. An `imageset.json` file will be created in the current working directory. The output JSON format is [documented here](#toolsetgenerateimagesetinfo).
+
+```
+Usage: oist build-manifest [options]
+
+build an image set manifest file and save to "imageset.json"
+
+Options:
+
+  -h, --help                    output usage information
+  -s, --source-directory <dir>  The directory to look for source images in
+```
+
 
 ### API Documentation
 
@@ -56,9 +87,9 @@ const toolSet = new OrigamiImageSetTools({
 });
 ```
 
-#### `toolSet.generateImageSetManifest()`
+#### `toolSet.buildImageSetManifest()`
 
-This function returns a promise which resolves with generated image set manifest. This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images.
+This function returns a promise which resolves with buildd image set manifest. This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images.
 
 The image manifest has the following format:
 
@@ -81,9 +112,9 @@ The image manifest has the following format:
 }
 ```
 
-#### `toolSet.generateImageSetManifestFile()`
+#### `toolSet.buildImageSetManifestFile()`
 
-This function returns a promise which generates image set information (using `generateImageSetManifest`) then saves it to a file as JSON.
+This function returns a promise which builds image set information (using `buildImageSetManifest`) then saves it to a file as JSON.
 
 This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images and where to save the file. The file will be created at `<baseDirectory>/imageset.json`.
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,44 @@ const toolSet = new OrigamiImageSetTools({
 });
 ```
 
+#### `toolSet.generateImageSetManifest()`
+
+This function returns a promise which resolves with generated image set manifest. This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images.
+
+The image manifest has the following format:
+
+```js
+{
+    // The directory the images were sourced from
+    sourceDirectory: 'src',
+
+    // A list of the found images
+    images: [
+
+        // The name, extension, and full path of each image
+        {
+            name: 'myimage',
+            extension: 'svg',
+            path: 'src/myimage.svg'
+        }
+
+    ]
+}
+```
+
+#### `toolSet.generateImageSetManifestFile()`
+
+This function returns a promise which generates image set information (using `generateImageSetManifest`) then saves it to a file as JSON.
+
+This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images and where to save the file. The file will be created at `<baseDirectory>/imageset.json`.
+
 #### Options
 
 The Origami Image Set Tools module can be configured with a variety of options, passed in as an object to the `OrigamiImageSetTools` function. The available options are as follows:
 
+  - `baseDirectory`: The base directory of the image set, where the manifest files sit. Image set JSON files will be created here. Defaults to the current working directory
   - `log`: A console object used to output non-request logs. Defaults to the global `console` object
+  - `sourceDirectory`: The directory relative to `baseDirectory` where the actual image files are located. Defaults to `"src"`
 
 
 Contributing

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const toolSet = new OrigamiImageSetTools({
 
 #### `toolSet.buildImageSetManifest()`
 
-This function returns a promise which resolves with buildd image set manifest. This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images.
+This function returns a promise which resolves with a built image set manifest. This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images.
 
 The image manifest has the following format:
 

--- a/bin/origami-image-set-tools.js
+++ b/bin/origami-image-set-tools.js
@@ -2,6 +2,43 @@
 'use strict';
 
 const OrigamiImageSetTools = require('../');
+const pkg = require('../package.json');
+const program = require('commander');
 
-const toolSet = new OrigamiImageSetTools();
-toolSet.log.info('Nothing to see here…');
+// Command to build a manifest file
+program
+	.command('build-manifest')
+	.option('-s, --source-directory <dir>', 'The directory to look for source images in')
+	.description('build an image set manifest file and save to "imageset.json"')
+	.action(options => {
+		const toolSet = new OrigamiImageSetTools({
+			sourceDirectory: options.sourceDirectory
+		});
+		toolSet.log.info('Building manifest file…');
+		toolSet.buildImageSetManifestFile()
+			.then(() => {
+				toolSet.log.info('✔︎ Manifest file saved');
+			})
+			.catch(error => {
+				toolSet.log.error('✘ Manifest file could not be saved');
+				toolSet.log.error(error.stack);
+				process.exit(1);
+			});
+	});
+
+// Output help for all unrecognised commands
+program
+	.command('*')
+	.description('unrecognised commands will output this help page')
+	.action(command => {
+		console.error(`Command "${command}" not found`);
+		process.exit(1);
+	});
+
+program
+	.version(pkg.version)
+	.parse(process.argv);
+
+if (!process.argv.slice(2).length) {
+	program.outputHelp();
+}

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -22,10 +22,14 @@ module.exports = class OrigamiImageSetTools {
 	 * Generate an object containing information about the image set.
 	 * @returns {Promise} A promise which resolves with a manifest object.
 	 */
-	generateImageSetManifest() {
+	buildImageSetManifest() {
 		const sourceDirectory = this.options.sourceDirectory;
 		const fullDirectory = path.join(this.options.baseDirectory, sourceDirectory);
+
+		// Read the source directory...
 		return fs.readdir(fullDirectory).then(filePaths => {
+
+			// Iterate over the file paths, creating image objects
 			const images = filePaths.filter(isImageFile).map(filePath => {
 				const fileExtension = path.extname(filePath);
 				const fileName = path.basename(filePath, fileExtension);
@@ -46,8 +50,8 @@ module.exports = class OrigamiImageSetTools {
 	 * Generate an image set manifest and saves it to a file.
 	 * @returns {Promise} A promise which resolves when the file is written.
 	 */
-	generateImageSetManifestFile() {
-		return this.generateImageSetManifest().then(imageSetManifest => {
+	buildImageSetManifestFile() {
+		return this.buildImageSetManifest().then(imageSetManifest => {
 			const filePath = path.join(this.options.baseDirectory, 'imageset.json');
 			const fileContents = JSON.stringify(imageSetManifest, null, '\t');
 			return fs.writeFile(filePath, fileContents);

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const defaults = require('lodash/defaults');
+const fs = require('fs-promise');
+const path = require('path');
 
 /**
  * Origami image set tools.
@@ -8,12 +10,48 @@ const defaults = require('lodash/defaults');
 module.exports = class OrigamiImageSetTools {
 
 	/**
-	 * Create a tool set.
+	 * Create a image tool set.
 	 * @param {Object} [options] - The instance options.
 	 */
 	constructor(options) {
 		this.options = defaults({}, options, module.exports.defaults);
 		this.log = this.options.log;
+	}
+
+	/**
+	 * Generate an object containing information about the image set.
+	 * @returns {Promise} A promise which resolves with a manifest object.
+	 */
+	generateImageSetManifest() {
+		const sourceDirectory = this.options.sourceDirectory;
+		const fullDirectory = path.join(this.options.baseDirectory, sourceDirectory);
+		return fs.readdir(fullDirectory).then(filePaths => {
+			const images = filePaths.filter(isImageFile).map(filePath => {
+				const fileExtension = path.extname(filePath);
+				const fileName = path.basename(filePath, fileExtension);
+				return {
+					name: fileName,
+					extension: fileExtension.slice(1),
+					path: path.join(sourceDirectory, filePath)
+				};
+			});
+			return {
+				sourceDirectory,
+				images
+			};
+		});
+	}
+
+	/**
+	 * Generate an image set manifest and saves it to a file.
+	 * @returns {Promise} A promise which resolves when the file is written.
+	 */
+	generateImageSetManifestFile() {
+		return this.generateImageSetManifest().then(imageSetManifest => {
+			const filePath = path.join(this.options.baseDirectory, 'imageset.json');
+			const fileContents = JSON.stringify(imageSetManifest, null, '\t');
+			return fs.writeFile(filePath, fileContents);
+		});
 	}
 
 };
@@ -23,5 +61,29 @@ module.exports = class OrigamiImageSetTools {
  * @static
  */
 module.exports.defaults = {
-	log: console
+	baseDirectory: process.cwd(),
+	log: console,
+	sourceDirectory: 'src'
 };
+
+/**
+ * A list of valid image file extensions.
+ * @access private
+ */
+const imageFileExtensions = [
+	'gif',
+	'jpg',
+	'png',
+	'svg'
+];
+
+/**
+ * Determine whether a file path points to an image file.
+ * @access private
+ * @param {String} filePath - The file path to check.
+ * @returns {Boolean} Whether the file path points to an image file.
+ */
+function isImageFile(filePath) {
+	const fileExtension = path.extname(filePath).slice(1);
+	return imageFileExtensions.includes(fileExtension);
+}

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.14.0",
+    "commander": "^2.9.0",
     "fs-promise": "^2.0.0",
     "lodash": "^4.17.4"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.14.0",
+    "fs-promise": "^2.0.0",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/test/integration/cli-build-manifest.js
+++ b/test/integration/cli-build-manifest.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const assert = require('proclaim');
+const fs = require('fs');
+const path = require('path');
+
+describe('oist build-manifest', () => {
+
+	before(() => {
+		fs.mkdirSync(path.join(global.testDirectory, 'src'));
+		fs.writeFileSync(path.join(global.testDirectory, 'src', 'example.png'), '');
+		return global.cliCall([
+			'build-manifest'
+		]);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /building manifest file/i);
+		assert.match(global.cliCall.lastResult.output, /manifest file saved/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+	it('creates the manifest file', () => {
+		const manifestPath = path.join(global.testDirectory, 'imageset.json');
+		const manifestContents = fs.readFileSync(manifestPath);
+		let manifestJson;
+		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
+		assert.deepEqual(manifestJson, {
+			sourceDirectory: 'src',
+			images: [
+				{
+					name: 'example',
+					extension: 'png',
+					path: 'src/example.png'
+				}
+			]
+		});
+	});
+
+});
+
+describe('oist build-manifest --source-directory is-a-directory', () => {
+
+	before(() => {
+		fs.mkdirSync(path.join(global.testDirectory, 'is-a-directory'));
+		return global.cliCall([
+			'build-manifest',
+			'--source-directory',
+			'is-a-directory'
+		]);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /building manifest file/i);
+		assert.match(global.cliCall.lastResult.output, /manifest file saved/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+	it('creates the manifest file', () => {
+		const manifestPath = path.join(global.testDirectory, 'imageset.json');
+		const manifestContents = fs.readFileSync(manifestPath);
+		let manifestJson;
+		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
+		assert.deepEqual(manifestJson, {
+			sourceDirectory: 'is-a-directory',
+			images: []
+		});
+	});
+
+});
+
+describe('oist build-manifest --source-directory not-a-directory', () => {
+
+	before(() => {
+		return global.cliCall([
+			'build-manifest',
+			'--source-directory',
+			'not-a-directory'
+		]);
+	});
+
+	it('outputs an error', () => {
+		assert.match(global.cliCall.lastResult.output, /building manifest file/i);
+		assert.match(global.cliCall.lastResult.output, /manifest file could not be saved/i);
+	});
+
+	it('exits with a code of 1', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 1);
+	});
+
+});

--- a/test/integration/cli-help.js
+++ b/test/integration/cli-help.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const assert = require('proclaim');
+
+describe('oist', () => {
+
+	before(() => {
+		return global.cliCall([]);
+	});
+
+	it('outputs help', () => {
+		assert.match(global.cliCall.lastResult.output, /usage:/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+});
+
+describe('oist --help', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--help'
+		]);
+	});
+
+	it('outputs help', () => {
+		assert.match(global.cliCall.lastResult.output, /usage:/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+});
+
+describe('oist not-a-command', () => {
+
+	before(() => {
+		return global.cliCall([
+			'not-a-command'
+		]);
+	});
+
+	it('outputs an error', () => {
+		assert.strictEqual(global.cliCall.lastResult.output, 'Command "not-a-command" not found');
+	});
+
+	it('exits with a code of 1', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 1);
+	});
+
+});

--- a/test/integration/cli-version.js
+++ b/test/integration/cli-version.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('proclaim');
+
+describe('oist --version', () => {
+
+	before(() => {
+		return global.cliCall([
+			'--version'
+		]);
+	});
+
+	it('outputs a version number', () => {
+		assert.strictEqual(global.cliCall.lastResult.output, '0.0.0');
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+});

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const spawn = require('child_process').spawn;
+
+global.testDirectory = fs.mkdtempSync('/tmp/oist-integration');
+
+// Export a global cliCall function as a test helper
+global.cliCall = cliCall;
+global.cliCall.lastResult = null;
+
+function cliCall(cliArguments) {
+
+	const command = path.resolve(__dirname, '../../bin/origami-image-set-tools.js');
+	const result = {
+		output: '',
+		stdout: '',
+		stderr: '',
+		code: 0
+	};
+
+	return new Promise(resolve => {
+		const child = spawn(command, cliArguments || [], {
+			cwd: global.testDirectory,
+			env: process.env
+		});
+		child.stdout.on('data', data => {
+			result.stdout += data;
+			result.output += data;
+		});
+		child.stderr.on('data', data => {
+			result.stderr += data;
+			result.output += data;
+		});
+		child.on('close', code => {
+			result.output = result.output.trim();
+			result.stdout = result.stdout.trim();
+			result.stderr = result.stderr.trim();
+			result.code = code;
+			global.cliCall.lastResult = result;
+			resolve(result);
+		});
+	});
+
+}

--- a/test/unit/lib/origami-image-set-tools.js
+++ b/test/unit/lib/origami-image-set-tools.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 
 describe('lib/origami-image-set-tools', () => {
 	let defaults;
+	let fs;
 	let log;
 	let OrigamiImageSetTools;
 
@@ -13,8 +14,10 @@ describe('lib/origami-image-set-tools', () => {
 		defaults = sinon.spy(require('lodash/defaults'));
 		mockery.registerMock('lodash/defaults', defaults);
 
+		fs = require('../mock/fs-promise.mock');
+		mockery.registerMock('fs-promise', fs);
+
 		log = require('../mock/log.mock');
-		mockery.registerMock('log', log);
 
 		OrigamiImageSetTools = require('../../..');
 	});
@@ -29,8 +32,16 @@ describe('lib/origami-image-set-tools', () => {
 
 	describe('.defaults', () => {
 
+		it('has a `baseDirectory` property', () => {
+			assert.strictEqual(OrigamiImageSetTools.defaults.baseDirectory, process.cwd());
+		});
+
 		it('has a `log` property', () => {
 			assert.strictEqual(OrigamiImageSetTools.defaults.log, console);
+		});
+
+		it('has a `sourceDirectory` property', () => {
+			assert.strictEqual(OrigamiImageSetTools.defaults.sourceDirectory, 'src');
 		});
 
 	});
@@ -41,7 +52,9 @@ describe('lib/origami-image-set-tools', () => {
 
 		beforeEach(() => {
 			options = {
-				log: log
+				baseDirectory: 'foo',
+				log: log,
+				sourceDirectory: 'bar'
 			};
 			instance = new OrigamiImageSetTools(options);
 		});
@@ -60,6 +73,109 @@ describe('lib/origami-image-set-tools', () => {
 
 			it('has a `log` property set to `options.log`', () => {
 				assert.strictEqual(instance.log, instance.options.log);
+			});
+
+			it('has a `generateImageSetManifest` method', () => {
+				assert.isFunction(instance.generateImageSetManifest);
+			});
+
+			describe('.generateImageSetManifest()', () => {
+				let resolvedValue;
+				let returnedPromise;
+
+				beforeEach(() => {
+
+					fs.readdir.resolves([
+						'.hidden-1',
+						'image-1.jpg',
+						'image-2.png',
+						'text-1.txt',
+						'image-3.svg',
+						'image-4.gif',
+						'directory-1'
+					]);
+
+					return returnedPromise = instance.generateImageSetManifest().then(value => {
+						resolvedValue = value;
+					});
+				});
+
+				it('returns a promise', () => {
+					assert.instanceOf(returnedPromise, Promise);
+				});
+
+				it('reads the configured source directory', () => {
+					assert.calledOnce(fs.readdir);
+					assert.calledWithExactly(fs.readdir, `${options.baseDirectory}/${options.sourceDirectory}`);
+				});
+
+				it('resolves with an object that contains the image names', () => {
+					assert.deepEqual(resolvedValue, {
+						sourceDirectory: options.sourceDirectory,
+						images: [
+							{
+								name: 'image-1',
+								extension: 'jpg',
+								path: `${options.sourceDirectory}/image-1.jpg`
+							},
+							{
+								name: 'image-2',
+								extension: 'png',
+								path: `${options.sourceDirectory}/image-2.png`
+							},
+							{
+								name: 'image-3',
+								extension: 'svg',
+								path: `${options.sourceDirectory}/image-3.svg`
+							},
+							{
+								name: 'image-4',
+								extension: 'gif',
+								path: `${options.sourceDirectory}/image-4.gif`
+							}
+						]
+					});
+				});
+
+			});
+
+			it('has a `generateImageSetManifestFile` method', () => {
+				assert.isFunction(instance.generateImageSetManifestFile);
+			});
+
+			describe('.generateImageSetManifestFile()', () => {
+				let imageSetManifest;
+				let resolvedValue;
+				let returnedPromise;
+
+				beforeEach(() => {
+					imageSetManifest = {
+						isMockInfo: true
+					};
+					instance.generateImageSetManifest = sinon.stub().resolves(imageSetManifest);
+
+					return returnedPromise = instance.generateImageSetManifestFile().then(value => {
+						resolvedValue = value;
+					});
+				});
+
+				it('returns a promise', () => {
+					assert.instanceOf(returnedPromise, Promise);
+				});
+
+				it('generates an image set manifest', () => {
+					assert.calledOnce(instance.generateImageSetManifest);
+				});
+
+				it('saves the image set manifest to a file as JSON', () => {
+					assert.calledOnce(fs.writeFile);
+					assert.calledWithExactly(fs.writeFile, `${options.baseDirectory}/imageset.json`, JSON.stringify(imageSetManifest, null, '\t'));
+				});
+
+				it('resolves with `undefined`', () => {
+					assert.isUndefined(resolvedValue);
+				});
+
 			});
 
 		});

--- a/test/unit/lib/origami-image-set-tools.js
+++ b/test/unit/lib/origami-image-set-tools.js
@@ -75,11 +75,11 @@ describe('lib/origami-image-set-tools', () => {
 				assert.strictEqual(instance.log, instance.options.log);
 			});
 
-			it('has a `generateImageSetManifest` method', () => {
-				assert.isFunction(instance.generateImageSetManifest);
+			it('has a `buildImageSetManifest` method', () => {
+				assert.isFunction(instance.buildImageSetManifest);
 			});
 
-			describe('.generateImageSetManifest()', () => {
+			describe('.buildImageSetManifest()', () => {
 				let resolvedValue;
 				let returnedPromise;
 
@@ -95,7 +95,7 @@ describe('lib/origami-image-set-tools', () => {
 						'directory-1'
 					]);
 
-					return returnedPromise = instance.generateImageSetManifest().then(value => {
+					return returnedPromise = instance.buildImageSetManifest().then(value => {
 						resolvedValue = value;
 					});
 				});
@@ -139,11 +139,11 @@ describe('lib/origami-image-set-tools', () => {
 
 			});
 
-			it('has a `generateImageSetManifestFile` method', () => {
-				assert.isFunction(instance.generateImageSetManifestFile);
+			it('has a `buildImageSetManifestFile` method', () => {
+				assert.isFunction(instance.buildImageSetManifestFile);
 			});
 
-			describe('.generateImageSetManifestFile()', () => {
+			describe('.buildImageSetManifestFile()', () => {
 				let imageSetManifest;
 				let resolvedValue;
 				let returnedPromise;
@@ -152,9 +152,9 @@ describe('lib/origami-image-set-tools', () => {
 					imageSetManifest = {
 						isMockInfo: true
 					};
-					instance.generateImageSetManifest = sinon.stub().resolves(imageSetManifest);
+					instance.buildImageSetManifest = sinon.stub().resolves(imageSetManifest);
 
-					return returnedPromise = instance.generateImageSetManifestFile().then(value => {
+					return returnedPromise = instance.buildImageSetManifestFile().then(value => {
 						resolvedValue = value;
 					});
 				});
@@ -163,8 +163,8 @@ describe('lib/origami-image-set-tools', () => {
 					assert.instanceOf(returnedPromise, Promise);
 				});
 
-				it('generates an image set manifest', () => {
-					assert.calledOnce(instance.generateImageSetManifest);
+				it('builds an image set manifest', () => {
+					assert.calledOnce(instance.buildImageSetManifest);
 				});
 
 				it('saves the image set manifest to a file as JSON', () => {

--- a/test/unit/mock/fs-promise.mock.js
+++ b/test/unit/mock/fs-promise.mock.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+module.exports = {
+	readdir: sinon.stub().resolves(),
+	writeFile: sinon.stub().resolves()
+};


### PR DESCRIPTION
This makes the tool actually useful. It might be easiest to look a the README to understand the functionality that this PR adds: https://github.com/Financial-Times/origami-image-set-tools/tree/generate-image-set-info#readme