### PR TITLE
Add an option to build the legacy manifest format

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Options:
 
   -h, --help                    output usage information
   -s, --source-directory <dir>  The directory to look for source images in
+  -l, --legacy                  Whether to output the legacy manifest format
 ```
 
 Options can also be set as environment variables:
@@ -142,11 +143,37 @@ The image manifest has the following format:
 }
 ```
 
+#### `toolSet.buildLegacyImageSetManifest()`
+
+This function returns a promise which resolves with a built legacy image set manifest. This is a stripped down version of the `buildImageSetManifest` method.
+
+The legacy image manifest has the following format:
+
+```js
+{
+    // A list of the found images
+    images: [
+
+        // The name of each image
+        {
+            name: 'myimage'
+        }
+
+    ]
+}
+```
+
 #### `toolSet.buildImageSetManifestFile()`
 
 This function returns a promise which builds image set information (using `buildImageSetManifest`) then saves it to a file as JSON.
 
 This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images and where to save the file. The file will be created at `<baseDirectory>/imageset.json`.
+
+#### `toolSet.buildLegacyImageSetManifestFile()`
+
+This function returns a promise which builds legacy image set information (using `buildLegacyImageSetManifest`) then saves it to a file as JSON.
+
+This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images and where to save the file. The file will be created at `<baseDirectory>/imageList.json`.
 
 #### `toolSet.publishToS3( bucket )`
 

--- a/bin/origami-image-set-tools.js
+++ b/bin/origami-image-set-tools.js
@@ -9,12 +9,14 @@ const program = require('commander');
 program
 	.command('build-manifest')
 	.option('-s, --source-directory <dir>', 'The directory to look for source images in', process.env.IMAGESET_SOURCE_DIRECTORY)
+	.option('-l, --legacy', 'Whether to output the legacy manifest format')
 	.description('build an image set manifest file and save to "imageset.json"')
 	.action(options => {
 		const toolSet = new OrigamiImageSetTools({
 			sourceDirectory: options.sourceDirectory
 		});
-		toolSet.buildImageSetManifestFile().catch(error => {
+		const buildFunction = (options.legacy ? 'buildLegacyImageSetManifestFile' : 'buildImageSetManifestFile');
+		toolSet[buildFunction]().catch(error => {
 			toolSet.log.error(error.stack);
 			process.exit(1);
 		});

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -52,6 +52,22 @@ module.exports = class OrigamiImageSetTools {
 	}
 
 	/**
+	 * Generate an object containing information about the image set in the legacy format.
+	 * @returns {Promise} A promise which resolves with a legacy manifest object.
+	 */
+	buildLegacyImageSetManifest() {
+		return this.buildImageSetManifest().then(manifest => {
+			return {
+				images: manifest.images.map(image => {
+					return {
+						name: image.name
+					};
+				})
+			};
+		});
+	}
+
+	/**
 	 * Generate an image set manifest and saves it to a file.
 	 * @returns {Promise} A promise which resolves when the file is written.
 	 */
@@ -68,6 +84,27 @@ module.exports = class OrigamiImageSetTools {
 			})
 			.catch(error => {
 				this.log.error('✘ Manifest file could not be saved');
+				throw error;
+			});
+	}
+
+	/**
+	 * Generate a legacy image set manifest and saves it to a file.
+	 * @returns {Promise} A promise which resolves when the file is written.
+	 */
+	buildLegacyImageSetManifestFile() {
+		this.log.info('Building legacy manifest file…');
+		return this.buildLegacyImageSetManifest()
+			.then(legacyImageSetManifest => {
+				const filePath = path.join(this.options.baseDirectory, 'imageList.json');
+				const fileContents = JSON.stringify(legacyImageSetManifest, null, '\t');
+				return fs.writeFile(filePath, fileContents);
+			})
+			.then(() => {
+				this.log.info('✔︎ Legacy manifest file saved');
+			})
+			.catch(error => {
+				this.log.error('✘ Legacy manifest file could not be saved');
 				throw error;
 			});
 	}

--- a/test/integration/cli-build-manifest.js
+++ b/test/integration/cli-build-manifest.js
@@ -126,6 +126,49 @@ describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory oist build-manifest', () => {
 
 });
 
+describe('oist build-manifest --legacy', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'src');
+		fs.mkdirSync(sourceDirectory);
+		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
+		return global.cliCall([
+			'build-manifest',
+			'--legacy'
+		]);
+	});
+
+	after(() => {
+		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /building legacy manifest file/i);
+		assert.match(global.cliCall.lastResult.output, /legacy manifest file saved/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+	it('creates the legacy manifest file', () => {
+		const manifestPath = path.join(global.testDirectory, 'imageList.json');
+		const manifestContents = fs.readFileSync(manifestPath);
+		let manifestJson;
+		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
+		assert.deepEqual(manifestJson, {
+			images: [
+				{
+					name: 'example'
+				}
+			]
+		});
+	});
+
+});
+
 describe('oist build-manifest --source-directory not-a-directory', () => {
 
 	before(() => {


### PR DESCRIPTION
This reduces work I need to do immediately, and we can deprecate this format when we have time to work on the registry side of things.

You can now call `oist build-manifest --legacy` to output the current format `imageList.json`.