### PR TITLE
Add the image set scheme to the manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Usage: oist [options] [command]
 Commands:
 
   build-manifest [options]   build an image set manifest file and save to "imageset.json"
+  publish-s3 [options]       publish the image set to an S3 bucket for use by the Image Service
   *                          unrecognised commands will output this help page
 
 Options:
@@ -66,12 +67,14 @@ Options:
 
   -h, --help                    output usage information
   -s, --source-directory <dir>  The directory to look for source images in
+  -c, --scheme <scheme>         The custom scheme this image set should be published under
   -l, --legacy                  Whether to output the legacy manifest format
 ```
 
 Options can also be set as environment variables:
 
   - `--source-directory` can be set with `IMAGESET_SOURCE_DIRECTORY`
+  - `--scheme` can be set with `IMAGESET_SCHEME`
 
 #### Publish to S3
 
@@ -128,6 +131,10 @@ The image manifest has the following format:
 {
     // The directory the images were sourced from
     sourceDirectory: 'src',
+
+    // The custom scheme the images should be stored
+    // under in the Image Service
+    scheme: 'ftexample',
 
     // A list of the found images
     images: [

--- a/bin/origami-image-set-tools.js
+++ b/bin/origami-image-set-tools.js
@@ -9,10 +9,12 @@ const program = require('commander');
 program
 	.command('build-manifest')
 	.option('-s, --source-directory <dir>', 'The directory to look for source images in', process.env.IMAGESET_SOURCE_DIRECTORY)
+	.option('-c, --scheme <scheme>', 'The custom scheme this image set should be published under', process.env.IMAGESET_SCHEME)
 	.option('-l, --legacy', 'Whether to output the legacy manifest format')
 	.description('build an image set manifest file and save to "imageset.json"')
 	.action(options => {
 		const toolSet = new OrigamiImageSetTools({
+			scheme: options.scheme,
 			sourceDirectory: options.sourceDirectory
 		});
 		const buildFunction = (options.legacy ? 'buildLegacyImageSetManifestFile' : 'buildImageSetManifestFile');

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -30,6 +30,7 @@ module.exports = class OrigamiImageSetTools {
 	buildImageSetManifest() {
 		const sourceDirectory = this.options.sourceDirectory;
 		const fullDirectory = path.join(this.options.baseDirectory, sourceDirectory);
+		const scheme = this.options.scheme;
 
 		// Read the source directory...
 		return fs.readdir(fullDirectory).then(filePaths => {
@@ -46,6 +47,7 @@ module.exports = class OrigamiImageSetTools {
 			});
 			return {
 				sourceDirectory,
+				scheme,
 				images
 			};
 		});

--- a/test/integration/cli-build-manifest.js
+++ b/test/integration/cli-build-manifest.js
@@ -37,6 +37,7 @@ describe('oist build-manifest', () => {
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
 			sourceDirectory: 'src',
+			scheme: 'noscheme',
 			images: [
 				{
 					name: 'example',
@@ -81,6 +82,7 @@ describe('oist build-manifest --source-directory is-a-directory', () => {
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
 			sourceDirectory: 'is-a-directory',
+			scheme: 'noscheme',
 			images: []
 		});
 	});
@@ -120,6 +122,86 @@ describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory oist build-manifest', () => {
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
 			sourceDirectory: 'is-a-directory',
+			scheme: 'noscheme',
+			images: []
+		});
+	});
+
+});
+
+describe('oist build-manifest --scheme test-scheme', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'src');
+		fs.mkdirSync(sourceDirectory);
+		return global.cliCall([
+			'build-manifest',
+			'--scheme', 'test-scheme'
+		]);
+	});
+
+	after(() => {
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /building manifest file/i);
+		assert.match(global.cliCall.lastResult.output, /manifest file saved/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+	it('creates the manifest file', () => {
+		const manifestPath = path.join(global.testDirectory, 'imageset.json');
+		const manifestContents = fs.readFileSync(manifestPath);
+		let manifestJson;
+		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
+		assert.deepEqual(manifestJson, {
+			sourceDirectory: 'src',
+			scheme: 'test-scheme',
+			images: []
+		});
+	});
+
+});
+
+describe('IMAGESET_SCHEME=test-scheme oist build-manifest', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'src');
+		fs.mkdirSync(sourceDirectory);
+		return global.cliCall([
+			'build-manifest'
+		], {
+			IMAGESET_SCHEME: 'test-scheme'
+		});
+	});
+
+	after(() => {
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /building manifest file/i);
+		assert.match(global.cliCall.lastResult.output, /manifest file saved/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+	it('creates the manifest file', () => {
+		const manifestPath = path.join(global.testDirectory, 'imageset.json');
+		const manifestContents = fs.readFileSync(manifestPath);
+		let manifestJson;
+		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
+		assert.deepEqual(manifestJson, {
+			sourceDirectory: 'src',
+			scheme: 'test-scheme',
 			images: []
 		});
 	});

--- a/test/unit/lib/origami-image-set-tools.js
+++ b/test/unit/lib/origami-image-set-tools.js
@@ -154,6 +154,7 @@ describe('lib/origami-image-set-tools', () => {
 				it('resolves with an object that contains the image names', () => {
 					assert.deepEqual(resolvedValue, {
 						sourceDirectory: options.sourceDirectory,
+						scheme: options.scheme,
 						images: [
 							{
 								name: 'image-1',
@@ -194,6 +195,7 @@ describe('lib/origami-image-set-tools', () => {
 
 					imageSetManifest = {
 						sourceDirectory: options.sourceDirectory,
+						scheme: options.scheme,
 						images: [
 							{
 								name: 'image-1',


### PR DESCRIPTION
This should reduce the number of requests that need to be made by the
registry, and will allow us to delete the imageset uploader.