### PR TITLE
Publish both with and without the file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ This uses the `awsAccessKey` and `awsSecretKey` [options](#options) to gain acce
 The `scheme` and `version` options are also used to calculate where the images will be uploaded to. If `scheme` is set to `myscheme` and `version` is set to `v4.5.6`, then:
 
 ```
-[LOCAL]/src/myimage.png === [S3]/myscheme/v4/myimage.png
+[LOCAL]/src/myimage.png === [S3]/myscheme/v4/myimage
 ```
 
 #### Options

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -131,22 +131,33 @@ module.exports = class OrigamiImageSetTools {
 		return this.buildImageSetManifest().then(imageSetManifest => {
 			return Promise.all(imageSetManifest.images.map(image => {
 				const fullPath = path.resolve(this.options.baseDirectory, image.path);
-				const s3Path = `${s3BasePath}/${image.name}.${image.extension}`;
+				const s3Path = `${s3BasePath}/${image.name}`;
+				const s3PathExt = `${s3Path}.${image.extension}`;
 				const s3Config = {
 					ACL: 'public-read',
 					Body: fs.createReadStream(fullPath),
 					ContentType: mime.lookup(fullPath),
 					Key: s3Path
 				};
+				const s3ConfigExt = {
+					ACL: s3Config.ACL,
+					Body: fs.createReadStream(fullPath),
+					ContentType: s3Config.ContentType,
+					Key: s3PathExt
+				};
 				this.log.info(`Publishing "${image.path}" to S3…`);
-				return s3.upload(s3Config).promise()
-					.then(() => {
-						this.log.info(`✔︎ Published "${image.path}" to S3 under "${s3Path}"`);
-					})
-					.catch(error => {
-						this.log.error(`✘ File "${image.path}" could not be published`);
-						throw error;
-					});
+				return Promise.all([
+					s3.upload(s3Config).promise(),
+					s3.upload(s3ConfigExt).promise()
+				])
+				.then(() => {
+					this.log.info(`✔︎ Published "${image.path}" to S3 under "${s3Path}"`);
+					this.log.info(`✔︎ Published "${image.path}" to S3 under "${s3PathExt}"`);
+				})
+				.catch(error => {
+					this.log.error(`✘ File "${image.path}" could not be published`);
+					throw error;
+				});
 			})).then(() => {
 				// empty block used to ensure that the promise resolves with `undefined`
 			});

--- a/test/integration/cli-publish-s3.js
+++ b/test/integration/cli-publish-s3.js
@@ -53,8 +53,8 @@ describe('oist publish-s3 --aws-access-key XXXXX --aws-secret-key XXXXX --bucket
 	before(() => {
 		sourceDirectory = path.join(global.testDirectory, 'src');
 		fs.mkdirSync(sourceDirectory);
-		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
-		fs.writeFileSync(path.join(sourceDirectory, 'example.jpg'), 'not-really-a-jpg');
+		fs.writeFileSync(path.join(sourceDirectory, 'example1.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'example2.jpg'), 'not-really-a-jpg');
 		return clearBucket().then(() => {
 			return global.cliCall([
 				'publish-s3',
@@ -66,33 +66,41 @@ describe('oist publish-s3 --aws-access-key XXXXX --aws-secret-key XXXXX --bucket
 	});
 
 	after(() => {
-		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
-		fs.unlinkSync(path.join(sourceDirectory, 'example.jpg'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example1.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example2.jpg'));
 		fs.rmdirSync(sourceDirectory);
 		return clearBucket();
 	});
 
 	it('outputs a success message', () => {
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.png" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.png" to s3 under "noscheme\/v0\/example.png"/i);
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.jpg" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.jpg" to s3 under "noscheme\/v0\/example.jpg"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1.png"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2.jpg"/i);
 	});
 
 	it('exits with a code of 0', () => {
 		assert.strictEqual(global.cliCall.lastResult.code, 0);
 	});
 
-	it('publishes the images to S3 under the expected key', () => {
+	it('publishes the images to S3 under the expected keys', () => {
 		const s3 = createS3Instance();
 		return Promise.all([
-			s3.getObject({Key: 'noscheme/v0/example.png'}).promise(),
-			s3.getObject({Key: 'noscheme/v0/example.jpg'}).promise()
+			s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
 		]).then(data => {
 			assert.strictEqual(data[0].ContentType, 'image/png');
 			assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
-			assert.strictEqual(data[1].ContentType, 'image/jpeg');
-			assert.strictEqual(data[1].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[1].ContentType, 'image/png');
+			assert.strictEqual(data[1].Body.toString(), 'not-really-a-png');
+			assert.strictEqual(data[2].ContentType, 'image/jpeg');
+			assert.strictEqual(data[2].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[3].ContentType, 'image/jpeg');
+			assert.strictEqual(data[3].Body.toString(), 'not-really-a-jpg');
 		});
 	});
 
@@ -104,8 +112,8 @@ describe('AWS_ACCESS_KEY=XXXXX AWS_SECRET_KEY=XXXXX AWS_BUCKET=origami-imageset-
 	before(() => {
 		sourceDirectory = path.join(global.testDirectory, 'src');
 		fs.mkdirSync(sourceDirectory);
-		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
-		fs.writeFileSync(path.join(sourceDirectory, 'example.jpg'), 'not-really-a-jpg');
+		fs.writeFileSync(path.join(sourceDirectory, 'example1.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'example2.jpg'), 'not-really-a-jpg');
 		return clearBucket().then(() => {
 			return global.cliCall([
 				'publish-s3'
@@ -118,33 +126,41 @@ describe('AWS_ACCESS_KEY=XXXXX AWS_SECRET_KEY=XXXXX AWS_BUCKET=origami-imageset-
 	});
 
 	after(() => {
-		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
-		fs.unlinkSync(path.join(sourceDirectory, 'example.jpg'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example1.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example2.jpg'));
 		fs.rmdirSync(sourceDirectory);
 		return clearBucket();
 	});
 
 	it('outputs a success message', () => {
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.png" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.png" to s3 under "noscheme\/v0\/example.png"/i);
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.jpg" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.jpg" to s3 under "noscheme\/v0\/example.jpg"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1.png"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2.jpg"/i);
 	});
 
 	it('exits with a code of 0', () => {
 		assert.strictEqual(global.cliCall.lastResult.code, 0);
 	});
 
-	it('publishes the images to S3 under the expected key', () => {
+	it('publishes the images to S3 under the expected keys', () => {
 		const s3 = createS3Instance();
 		return Promise.all([
-			s3.getObject({Key: 'noscheme/v0/example.png'}).promise(),
-			s3.getObject({Key: 'noscheme/v0/example.jpg'}).promise()
+			s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
 		]).then(data => {
 			assert.strictEqual(data[0].ContentType, 'image/png');
 			assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
-			assert.strictEqual(data[1].ContentType, 'image/jpeg');
-			assert.strictEqual(data[1].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[1].ContentType, 'image/png');
+			assert.strictEqual(data[1].Body.toString(), 'not-really-a-png');
+			assert.strictEqual(data[2].ContentType, 'image/jpeg');
+			assert.strictEqual(data[2].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[3].ContentType, 'image/jpeg');
+			assert.strictEqual(data[3].Body.toString(), 'not-really-a-jpg');
 		});
 	});
 
@@ -156,8 +172,8 @@ describe('oist publish-s3 … --scheme test-scheme --scheme-version v4.5.6', () 
 	before(() => {
 		sourceDirectory = path.join(global.testDirectory, 'src');
 		fs.mkdirSync(sourceDirectory);
-		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
-		fs.writeFileSync(path.join(sourceDirectory, 'example.jpg'), 'not-really-a-jpg');
+		fs.writeFileSync(path.join(sourceDirectory, 'example1.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'example2.jpg'), 'not-really-a-jpg');
 		return clearBucket().then(() => {
 			return global.cliCall([
 				'publish-s3',
@@ -171,33 +187,41 @@ describe('oist publish-s3 … --scheme test-scheme --scheme-version v4.5.6', () 
 	});
 
 	after(() => {
-		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
-		fs.unlinkSync(path.join(sourceDirectory, 'example.jpg'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example1.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example2.jpg'));
 		fs.rmdirSync(sourceDirectory);
 		return clearBucket();
 	});
 
 	it('outputs a success message', () => {
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.png" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.png" to s3 under "test-scheme\/v4\/example.png"/i);
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.jpg" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.jpg" to s3 under "test-scheme\/v4\/example.jpg"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1.png"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2.jpg"/i);
 	});
 
 	it('exits with a code of 0', () => {
 		assert.strictEqual(global.cliCall.lastResult.code, 0);
 	});
 
-	it('publishes the images to S3 under the expected key', () => {
+	it('publishes the images to S3 under the expected keys', () => {
 		const s3 = createS3Instance();
 		return Promise.all([
-			s3.getObject({Key: 'test-scheme/v4/example.png'}).promise(),
-			s3.getObject({Key: 'test-scheme/v4/example.jpg'}).promise()
+			s3.getObject({Key: 'test-scheme/v4/example1'}).promise(),
+			s3.getObject({Key: 'test-scheme/v4/example1.png'}).promise(),
+			s3.getObject({Key: 'test-scheme/v4/example2'}).promise(),
+			s3.getObject({Key: 'test-scheme/v4/example2.jpg'}).promise()
 		]).then(data => {
 			assert.strictEqual(data[0].ContentType, 'image/png');
 			assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
-			assert.strictEqual(data[1].ContentType, 'image/jpeg');
-			assert.strictEqual(data[1].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[1].ContentType, 'image/png');
+			assert.strictEqual(data[1].Body.toString(), 'not-really-a-png');
+			assert.strictEqual(data[2].ContentType, 'image/jpeg');
+			assert.strictEqual(data[2].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[3].ContentType, 'image/jpeg');
+			assert.strictEqual(data[3].Body.toString(), 'not-really-a-jpg');
 		});
 	});
 
@@ -209,8 +233,8 @@ describe('IMAGESET_SCHEME=test-scheme IMAGESET_VERSION=v4.5.6 … oist publish-s
 	before(() => {
 		sourceDirectory = path.join(global.testDirectory, 'src');
 		fs.mkdirSync(sourceDirectory);
-		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
-		fs.writeFileSync(path.join(sourceDirectory, 'example.jpg'), 'not-really-a-jpg');
+		fs.writeFileSync(path.join(sourceDirectory, 'example1.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'example2.jpg'), 'not-really-a-jpg');
 		return clearBucket().then(() => {
 			return global.cliCall([
 				'publish-s3'
@@ -225,33 +249,41 @@ describe('IMAGESET_SCHEME=test-scheme IMAGESET_VERSION=v4.5.6 … oist publish-s
 	});
 
 	after(() => {
-		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
-		fs.unlinkSync(path.join(sourceDirectory, 'example.jpg'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example1.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example2.jpg'));
 		fs.rmdirSync(sourceDirectory);
 		return clearBucket();
 	});
 
 	it('outputs a success message', () => {
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.png" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.png" to s3 under "test-scheme\/v4\/example.png"/i);
-		assert.match(global.cliCall.lastResult.output, /publishing "src\/example.jpg" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "src\/example.jpg" to s3 under "test-scheme\/v4\/example.jpg"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1.png"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2"/i);
+		assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2.jpg"/i);
 	});
 
 	it('exits with a code of 0', () => {
 		assert.strictEqual(global.cliCall.lastResult.code, 0);
 	});
 
-	it('publishes the images to S3 under the expected key', () => {
+	it('publishes the images to S3 under the expected keys', () => {
 		const s3 = createS3Instance();
 		return Promise.all([
-			s3.getObject({Key: 'test-scheme/v4/example.png'}).promise(),
-			s3.getObject({Key: 'test-scheme/v4/example.jpg'}).promise()
+			s3.getObject({Key: 'test-scheme/v4/example1'}).promise(),
+			s3.getObject({Key: 'test-scheme/v4/example1.png'}).promise(),
+			s3.getObject({Key: 'test-scheme/v4/example2'}).promise(),
+			s3.getObject({Key: 'test-scheme/v4/example2.jpg'}).promise()
 		]).then(data => {
 			assert.strictEqual(data[0].ContentType, 'image/png');
 			assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
-			assert.strictEqual(data[1].ContentType, 'image/jpeg');
-			assert.strictEqual(data[1].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[1].ContentType, 'image/png');
+			assert.strictEqual(data[1].Body.toString(), 'not-really-a-png');
+			assert.strictEqual(data[2].ContentType, 'image/jpeg');
+			assert.strictEqual(data[2].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[3].ContentType, 'image/jpeg');
+			assert.strictEqual(data[3].Body.toString(), 'not-really-a-jpg');
 		});
 	});
 
@@ -263,8 +295,8 @@ describe('oist publish-s3 … --source-directory is-a-directory', () => {
 	before(() => {
 		sourceDirectory = path.join(global.testDirectory, 'is-a-directory');
 		fs.mkdirSync(sourceDirectory);
-		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
-		fs.writeFileSync(path.join(sourceDirectory, 'example.jpg'), 'not-really-a-jpg');
+		fs.writeFileSync(path.join(sourceDirectory, 'example1.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'example2.jpg'), 'not-really-a-jpg');
 		return clearBucket().then(() => {
 			return global.cliCall([
 				'publish-s3',
@@ -277,33 +309,39 @@ describe('oist publish-s3 … --source-directory is-a-directory', () => {
 	});
 
 	after(() => {
-		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
-		fs.unlinkSync(path.join(sourceDirectory, 'example.jpg'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example1.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example2.jpg'));
 		fs.rmdirSync(sourceDirectory);
 		return clearBucket();
 	});
 
 	it('outputs a success message', () => {
-		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example.png" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example.png" to s3 under "noscheme\/v0\/example.png"/i);
-		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example.jpg" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example.jpg" to s3 under "noscheme\/v0\/example.jpg"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example1.png" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example2.jpg" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
 	});
 
 	it('exits with a code of 0', () => {
 		assert.strictEqual(global.cliCall.lastResult.code, 0);
 	});
 
-	it('publishes the images to S3 under the expected key', () => {
+	it('publishes the images to S3 under the expected keys', () => {
 		const s3 = createS3Instance();
 		return Promise.all([
-			s3.getObject({Key: 'noscheme/v0/example.png'}).promise(),
-			s3.getObject({Key: 'noscheme/v0/example.jpg'}).promise()
+			s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
 		]).then(data => {
 			assert.strictEqual(data[0].ContentType, 'image/png');
 			assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
-			assert.strictEqual(data[1].ContentType, 'image/jpeg');
-			assert.strictEqual(data[1].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[1].ContentType, 'image/png');
+			assert.strictEqual(data[1].Body.toString(), 'not-really-a-png');
+			assert.strictEqual(data[2].ContentType, 'image/jpeg');
+			assert.strictEqual(data[2].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[3].ContentType, 'image/jpeg');
+			assert.strictEqual(data[3].Body.toString(), 'not-really-a-jpg');
 		});
 	});
 
@@ -315,8 +353,8 @@ describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory … oist publish-s3', () => {
 	before(() => {
 		sourceDirectory = path.join(global.testDirectory, 'is-a-directory');
 		fs.mkdirSync(sourceDirectory);
-		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
-		fs.writeFileSync(path.join(sourceDirectory, 'example.jpg'), 'not-really-a-jpg');
+		fs.writeFileSync(path.join(sourceDirectory, 'example1.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'example2.jpg'), 'not-really-a-jpg');
 		return clearBucket().then(() => {
 			return global.cliCall([
 				'publish-s3'
@@ -330,33 +368,39 @@ describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory … oist publish-s3', () => {
 	});
 
 	after(() => {
-		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
-		fs.unlinkSync(path.join(sourceDirectory, 'example.jpg'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example1.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'example2.jpg'));
 		fs.rmdirSync(sourceDirectory);
 		return clearBucket();
 	});
 
 	it('outputs a success message', () => {
-		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example.png" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example.png" to s3 under "noscheme\/v0\/example.png"/i);
-		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example.jpg" to s3/i);
-		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example.jpg" to s3 under "noscheme\/v0\/example.jpg"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example1.png" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
+		assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example2.jpg" to s3/i);
+		assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
 	});
 
 	it('exits with a code of 0', () => {
 		assert.strictEqual(global.cliCall.lastResult.code, 0);
 	});
 
-	it('publishes the images to S3 under the expected key', () => {
+	it('publishes the images to S3 under the expected keys', () => {
 		const s3 = createS3Instance();
 		return Promise.all([
-			s3.getObject({Key: 'noscheme/v0/example.png'}).promise(),
-			s3.getObject({Key: 'noscheme/v0/example.jpg'}).promise()
+			s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
+			s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
 		]).then(data => {
 			assert.strictEqual(data[0].ContentType, 'image/png');
 			assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
-			assert.strictEqual(data[1].ContentType, 'image/jpeg');
-			assert.strictEqual(data[1].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[1].ContentType, 'image/png');
+			assert.strictEqual(data[1].Body.toString(), 'not-really-a-png');
+			assert.strictEqual(data[2].ContentType, 'image/jpeg');
+			assert.strictEqual(data[2].Body.toString(), 'not-really-a-jpg');
+			assert.strictEqual(data[3].ContentType, 'image/jpeg');
+			assert.strictEqual(data[3].Body.toString(), 'not-really-a-jpg');
 		});
 	});
 


### PR DESCRIPTION
Gets us part of the way towards fixing https://github.com/Financial-Times/origami-image-service/issues/233