### PR TITLE
Add in image verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Commands:
 
   build-manifest [options]   build an image set manifest file and save to "imageset.json"
   publish-s3 [options]       publish the image set to an S3 bucket for use by the Image Service
+  verify [options]           verify that images in the source directory are valid and have no issues
   *                          unrecognised commands will output this help page
 
 Options:
@@ -102,6 +103,25 @@ Options can also be set as environment variables:
   - `--source-directory` can be set with `IMAGESET_SOURCE_DIRECTORY`
   - `--scheme` can be set with `IMAGESET_SCHEME`
   - `--scheme-version` can be set with `IMAGESET_VERSION`
+
+#### Verify
+
+The `oist verify` command checks all of the images in the set to ensure that they're valid.
+
+```
+Usage: oist verify [options]
+
+  verify that images in the source directory are valid and have no issues
+
+  Options:
+
+    -h, --help                    output usage information
+    -s, --source-directory <dir>  The directory to look for source images in
+```
+
+Options can also be set as environment variables:
+
+  - `--source-directory` can be set with `IMAGESET_SOURCE_DIRECTORY`
 
 ### API Documentation
 
@@ -193,6 +213,12 @@ The `scheme` and `version` options are also used to calculate where the images w
 ```
 [LOCAL]/src/myimage.png === [S3]/myscheme/v4/myimage
 ```
+
+#### `toolSet.verifyImages()`
+
+This function returns a promise which verifies that each image in the set is valid.
+
+This uses the `baseDirectory` and `sourceDirectory` [options](#options) to determine where to find images. If any verification fails, this method will reject with an error that has a `verificationErrors` property.
 
 #### Options
 

--- a/bin/origami-image-set-tools.js
+++ b/bin/origami-image-set-tools.js
@@ -48,6 +48,23 @@ program
 		});
 	});
 
+// Command to lint images
+program
+	.command('verify')
+	.option('-s, --source-directory <dir>', 'The directory to look for source images in', process.env.IMAGESET_SOURCE_DIRECTORY)
+	.option('-c, --scheme <scheme>', 'The custom scheme to publish this image set under', process.env.IMAGESET_SCHEME)
+	.description('verify that images in the source directory are valid and have no issues')
+	.action(options => {
+		const toolSet = new OrigamiImageSetTools({
+			scheme: options.scheme,
+			sourceDirectory: options.sourceDirectory
+		});
+		toolSet.verifyImages().catch(error => {
+			toolSet.log.error(error.stack);
+			process.exit(1);
+		});
+	});
+
 // Output help for all unrecognised commands
 program
 	.command('*')

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -6,6 +6,7 @@ const fs = require('fs-promise');
 const mime = require('mime-types');
 const path = require('path');
 const semver = require('semver');
+const xml = require('libxmljs');
 
 /**
  * Origami image set tools.
@@ -158,6 +159,67 @@ module.exports = class OrigamiImageSetTools {
 					this.log.error(`✘ File "${image.path}" could not be published`);
 					throw error;
 				});
+			})).then(() => {
+				// empty block used to ensure that the promise resolves with `undefined`
+			});
+		});
+	}
+
+	/**
+	 * Verify images in the manifest.
+	 * @returns {Promise} A promise which resolves when all the images pass verification.
+	 */
+	verifyImages() {
+		this.log.info('Verifying images…');
+		return this.verifySvgImages()
+			.then(() => {
+				this.log.info('✔︎ Verified all images');
+			});
+	}
+
+	/**
+	 * Verify SVG images in the manifest.
+	 * @returns {Promise} A promise which resolves when all the SVG images pass verification.
+	 */
+	verifySvgImages() {
+		return this.buildImageSetManifest().then(imageSetManifest => {
+			const svgImages = imageSetManifest.images.filter(image => {
+				return (image.extension.toLowerCase() === 'svg');
+			});
+			return Promise.all(svgImages.map(image => {
+				const fullPath = path.resolve(this.options.baseDirectory, image.path);
+				this.log.info(`Verifying "${image.path}"…`);
+				return fs.readFile(fullPath, 'utf-8')
+					.then(fileContents => {
+						const verificationErrors = [];
+						const svg = xml.parseXml(fileContents);
+
+						if (svg.root().attr('width')) {
+							verificationErrors.push('Root SVG element must not have a `width` attribute');
+						}
+						if (svg.root().attr('height')) {
+							verificationErrors.push('Root SVG element must not have a `height` attribute');
+						}
+
+						if (verificationErrors.length) {
+							const error = new Error('Verification errors');
+							error.verificationErrors = verificationErrors;
+							throw error;
+						} else {
+							this.log.info(`✔︎ File "${image.path}" has no issues`);
+						}
+					})
+					.catch(error => {
+						this.log.error(`✘ File "${image.path}" has some issues:`);
+						if (error.verificationErrors) {
+							error.verificationErrors.forEach(verificationError => {
+								this.log.error(`  - ${verificationError}`);
+							});
+						} else {
+							this.log.error(`  - ${error.message}`);
+						}
+						throw error;
+					});
 			})).then(() => {
 				// empty block used to ensure that the promise resolves with `undefined`
 			});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "aws-sdk": "^2.14.0",
     "commander": "^2.9.0",
     "fs-promise": "^2.0.0",
+    "libxmljs": "^0.18.7",
     "lodash": "^4.17.4",
     "mime-types": "^2.1.14",
     "semver": "^5.3.0"

--- a/test/integration/cli-verify.js
+++ b/test/integration/cli-verify.js
@@ -1,0 +1,144 @@
+'use strict';
+
+const assert = require('proclaim');
+const fs = require('fs');
+const path = require('path');
+
+describe('oist verify', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'src');
+		fs.mkdirSync(sourceDirectory);
+		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'valid.svg'), '<svg></svg>');
+		return global.cliCall([
+			'verify'
+		]);
+	});
+
+	after(() => {
+		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'valid.svg'));
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /verifying images/i);
+		assert.match(global.cliCall.lastResult.output, /verified all images/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+});
+
+describe('oist verify (with invalid images present)', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'src');
+		fs.mkdirSync(sourceDirectory);
+		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'valid.svg'), '<svg width="100" height="100"></svg>');
+		return global.cliCall([
+			'verify'
+		]);
+	});
+
+	after(() => {
+		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'valid.svg'));
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs an error', () => {
+		assert.match(global.cliCall.lastResult.output, /verifying images/i);
+		assert.match(global.cliCall.lastResult.output, /root svg element must not have a `width` attribute/i);
+		assert.match(global.cliCall.lastResult.output, /root svg element must not have a `height` attribute/i);
+	});
+
+	it('exits with a code of 1', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 1);
+	});
+
+});
+
+describe('oist verify --source-directory is-a-directory', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'is-a-directory');
+		fs.mkdirSync(sourceDirectory);
+		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'valid.svg'), '<svg></svg>');
+		return global.cliCall([
+			'verify',
+			'--source-directory', 'is-a-directory'
+		]);
+	});
+
+	after(() => {
+		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'valid.svg'));
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /verifying images/i);
+		assert.match(global.cliCall.lastResult.output, /verified all images/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+});
+
+describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory oist verify', () => {
+	let sourceDirectory;
+
+	before(() => {
+		sourceDirectory = path.join(global.testDirectory, 'is-a-directory');
+		fs.mkdirSync(sourceDirectory);
+		fs.writeFileSync(path.join(sourceDirectory, 'example.png'), 'not-really-a-png');
+		fs.writeFileSync(path.join(sourceDirectory, 'valid.svg'), '<svg></svg>');
+		return global.cliCall([
+			'verify'
+		], {
+			IMAGESET_SOURCE_DIRECTORY: 'is-a-directory'
+		});
+	});
+
+	after(() => {
+		fs.unlinkSync(path.join(sourceDirectory, 'example.png'));
+		fs.unlinkSync(path.join(sourceDirectory, 'valid.svg'));
+		fs.rmdirSync(sourceDirectory);
+	});
+
+	it('outputs a success message', () => {
+		assert.match(global.cliCall.lastResult.output, /verifying images/i);
+		assert.match(global.cliCall.lastResult.output, /verified all images/i);
+	});
+
+	it('exits with a code of 0', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 0);
+	});
+
+});
+
+describe('oist verify --source-directory not-a-directory', () => {
+
+	before(() => {
+		return global.cliCall([
+			'verify',
+			'--source-directory', 'not-a-directory'
+		]);
+	});
+
+	it('exits with a code of 1', () => {
+		assert.strictEqual(global.cliCall.lastResult.code, 1);
+	});
+
+});

--- a/test/unit/mock/fs-promise.mock.js
+++ b/test/unit/mock/fs-promise.mock.js
@@ -6,5 +6,6 @@ require('sinon-as-promised');
 module.exports = {
 	createReadStream: sinon.stub(),
 	readdir: sinon.stub().resolves(),
+	readFile: sinon.stub().resolves(),
 	writeFile: sinon.stub().resolves()
 };

--- a/test/unit/mock/libxmljs.mock.js
+++ b/test/unit/mock/libxmljs.mock.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const sinon = require('sinon');
+require('sinon-as-promised');
+
+const xml = module.exports = {
+	parseXml: sinon.stub()
+};
+
+xml.mockInstance = {
+	root: sinon.stub()
+};
+
+xml.mockRootNode = {
+	attr: sinon.stub().returns(null)
+};
+
+xml.parseXml.returns(xml.mockInstance);
+xml.mockInstance.root.returns(xml.mockRootNode);


### PR DESCRIPTION
This mostly gives us a way to verify SVGs. Currently it asserts that
there are no width and height attributes on the root node.