### PR TITLE
Add hash and previousHash properties to the manifest file

### DIFF
--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -50,9 +50,10 @@ module.exports = class OrigamiImageSetTools {
 				const hash = hasha.fromFileSync(path.join(fullDirectory, filePath));
 				let previousHash;
 				if (currentManifest && Array.isArray(currentManifest.images)) {
-					previousHash = currentManifest.images.find(image => {
+					const imageManifest = currentManifest.images.find(image => {
 						return (image.name === name && image.extension === extension && image.path === relativePath);
-					}).hash;
+					});
+					previousHash = imageManifest && imageManifest.hash;
 				}
 				return {
 					name,

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -9,6 +9,8 @@ const semver = require('semver');
 const semvish = require('semvish');
 const xml = require('libxmljs');
 const request = require('request-promise-native');
+const hasha = require('hasha');
+const fileExists = require('file-exists');
 
 /**
  * Origami image set tools.
@@ -32,21 +34,32 @@ module.exports = class OrigamiImageSetTools {
 	 * @returns {Promise} A promise which resolves with a manifest object.
 	 */
 	buildImageSetManifest() {
+		const currentManifest = this.readImageSetManifest();
 		const sourceDirectory = this.options.sourceDirectory;
 		const fullDirectory = path.join(this.options.baseDirectory, sourceDirectory);
 		const scheme = this.options.scheme;
-
+		const filePaths = fs.readdir(fullDirectory);
 		// Read the source directory...
-		return fs.readdir(fullDirectory).then(filePaths => {
-
+		return Promise.all([filePaths, currentManifest]).then(([filePaths, currentManifest]) => {
 			// Iterate over the file paths, creating image objects
 			const images = filePaths.filter(isImageFile).map(filePath => {
 				const fileExtension = path.extname(filePath);
-				const fileName = path.basename(filePath, fileExtension);
+				const name = path.basename(filePath, fileExtension);
+				const extension = fileExtension.slice(1);
+				const relativePath = path.join(sourceDirectory, filePath);
+				const hash = hasha.fromFileSync(path.join(fullDirectory, filePath));
+				let previousHash;
+				if (currentManifest && Array.isArray(currentManifest.images)) {
+					previousHash = currentManifest.images.find(image => {
+						return (image.name === name && image.extension === extension && image.path === relativePath);
+					}).hash;
+				}
 				return {
-					name: fileName,
-					extension: fileExtension.slice(1),
-					path: path.join(sourceDirectory, filePath)
+					name,
+					extension,
+					path: relativePath,
+					previousHash,
+					hash
 				};
 			});
 			return {
@@ -212,6 +225,28 @@ module.exports = class OrigamiImageSetTools {
 				// empty block used to ensure that the promise resolves with `undefined`
 			});
 		});
+	}
+
+	readImageSetManifest() {
+		const filePath = path.join(this.options.baseDirectory, 'imageset.json');
+		const legacyFilePath = path.join(this.options.baseDirectory, 'imageList.json');
+		const imageSetExists = fileExists(filePath);
+		const imageListExists = fileExists(legacyFilePath);
+		return Promise.all([imageSetExists, imageListExists])
+			.then(([imageSet, imageList]) => {
+				if (imageSet) {
+					return fs.readFile(filePath, 'utf8');
+				} else if (imageList) {
+					return fs.readFile(legacyFilePath, 'utf8');
+				} else {
+					return null;
+				}
+			})
+			.then(JSON.parse)
+			.catch(error => {
+				this.log.error('✘ Error reading manifest file as JSON');
+				throw error;
+			});
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -780,6 +780,11 @@
         "object-assign": "4.1.1"
       }
     },
+    "file-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/file-exists/-/file-exists-5.0.0.tgz",
+      "integrity": "sha512-MIMzBjsXrH20bF4TAF24U6MWsqXP4K8Pu/Xj+wX9oh3xKgRfRZ2Z0IPMPMfkVNbO6QeLKmGIyOpW2hVv/AipBA=="
+    },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
@@ -995,6 +1000,14 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "requires": {
+        "is-stream": "1.1.0"
+      }
+    },
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -1199,6 +1212,11 @@
       "requires": {
         "tryit": "1.0.3"
       }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "dependencies": {
     "aws-sdk": "^2.134.0",
     "commander": "^2.11.0",
+    "file-exists": "^5.0.0",
     "fs-promise": "^2.0.3",
+    "hasha": "^3.0.0",
     "libxmljs": "^0.18.7",
     "lodash": "^4.17.4",
     "mime-types": "^2.1.17",

--- a/test/integration/cli-build-manifest.test.js
+++ b/test/integration/cli-build-manifest.test.js
@@ -42,12 +42,12 @@ describe('oist build-manifest', () => {
 				{
 					name: 'example',
 					extension: 'png',
-					path: 'src/example.png'
+					path: 'src/example.png',
+					hash: '923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'
 				}
 			]
 		});
 	});
-
 });
 
 describe('oist build-manifest --source-directory is-a-directory', () => {

--- a/test/unit/mock/file-exists.mock.js
+++ b/test/unit/mock/file-exists.mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = sinon.stub().resolves();

--- a/test/unit/mock/hasha.mock.js
+++ b/test/unit/mock/hasha.mock.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = {
+	fromFileSync: sinon.stub()
+};


### PR DESCRIPTION
Based solely on the manifest file there is no way to tell which images have changed. By adding the hash and previous hash of the image (if we have it), we can figure out which images are brand new to the set and which images have been updated. This gets us a step closer to being able to purge _only_ updated images.