### PR TITLE
Include images hash in the filename of the image when publishing and include version and host in the imageset file

### DIFF
--- a/bin/origami-image-set-tools.js
+++ b/bin/origami-image-set-tools.js
@@ -10,12 +10,16 @@ program
 	.command('build-manifest')
 	.option('-s, --source-directory <dir>', 'The directory to look for source images in', process.env.IMAGESET_SOURCE_DIRECTORY)
 	.option('-c, --scheme <scheme>', 'The custom scheme this image set should be published under', process.env.IMAGESET_SCHEME)
+	.option('-v, --scheme-version <version>', 'The version to publish this image set under', process.env.IMAGESET_VERSION)
+	.option('-h, --host <hostname>', 'The hostname that the imageset is available on', process.env.HOST)
 	.option('-l, --legacy', 'Whether to output the legacy manifest format')
 	.description('build an image set manifest file and save to "imageset.json"')
 	.action(options => {
 		const toolSet = new OrigamiImageSetTools({
 			scheme: options.scheme,
-			sourceDirectory: options.sourceDirectory
+			sourceDirectory: options.sourceDirectory,
+			version: options.schemeVersion,
+			host: options.host
 		});
 		const buildFunction = (options.legacy ? 'buildLegacyImageSetManifestFile' : 'buildImageSetManifestFile');
 		toolSet[buildFunction]().catch(error => {

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -186,7 +186,7 @@ module.exports = class OrigamiImageSetTools {
 			}
 		});
 		const s3BasePath = `${this.scheme}/v${semver.major(this.options.version)}`;
-		const imageSetManifest = await (this.buildImageSetManifest());
+		const imageSetManifest = await (this.readImageSetManifest());
 		for (const image of imageSetManifest.images) {
 
 			const fullPath = path.resolve(this.options.baseDirectory, image.path);

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -21,7 +21,8 @@ const defaultOptions = {
 	log: console,
 	scheme: 'noscheme',
 	sourceDirectory: 'src',
-	version: 'v0.0.0'
+	version: 'v0.0.0',
+	host: 'https://www.ft.com'
 };
 
 /**
@@ -39,6 +40,7 @@ module.exports = class OrigamiImageSetTools {
 		this.scheme = this.options.scheme;
 		this.options.version = semvish.clean(this.options.version);
 		this.version = (semver.valid(this.options.version) ? this.options.version : OrigamiImageSetTools.defaults.version);
+		this.host = this.options.host;
 	}
 
 	/**
@@ -59,6 +61,8 @@ module.exports = class OrigamiImageSetTools {
 		const fullDirectory = path.join(this.options.baseDirectory, sourceDirectory);
 		const scheme = this.options.scheme;
 		const filePaths = fs.readdir(fullDirectory);
+		const version = this.version;
+		const host = this.host;
 		// Read the source directory...
 		return Promise.all([filePaths, currentManifest]).then(([filePaths, currentManifest]) => {
 			// Iterate over the file paths, creating image objects
@@ -82,6 +86,8 @@ module.exports = class OrigamiImageSetTools {
 				};
 			});
 			return {
+				version,
+				host,
 				sourceDirectory,
 				scheme,
 				images

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -189,7 +189,7 @@ module.exports = class OrigamiImageSetTools {
 			}
 		});
 		const s3BasePath = `${this.scheme}/v${semver.major(this.options.version)}`;
-		const imageSetManifest = await (this.readImageSetManifest());
+		const imageSetManifest = await (this.buildImageSetManifest());
 		for (const image of imageSetManifest.images) {
 
 			const fullPath = path.resolve(this.options.baseDirectory, image.path);

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -11,6 +11,7 @@ const xml = require('libxmljs');
 const request = require('request-promise-native');
 const hasha = require('hasha');
 const fileExists = require('file-exists');
+const URL = require('url').URL;
 
 const defaultOptions = {
 	awsAccessKey: null,
@@ -77,17 +78,19 @@ module.exports = class OrigamiImageSetTools {
 					const imageManifest = currentManifest.images.find(image => image.name === name && image.extension === extension && image.path === relativePath);
 					previousHash = imageManifest && imageManifest.hash;
 				}
+				const s3BasePath = `${this.scheme}/v${semver.major(version)}`;
+				const s3Path = `${s3BasePath}/${name}-${hash}`;
+				const url = new URL(s3Path, host).toString();
 				return {
 					name,
 					extension,
 					path: relativePath,
 					previousHash,
-					hash
+					hash,
+					url
 				};
 			});
 			return {
-				version,
-				host,
 				sourceDirectory,
 				scheme,
 				images

--- a/lib/origami-image-set-tools.js
+++ b/lib/origami-image-set-tools.js
@@ -184,7 +184,7 @@ module.exports = class OrigamiImageSetTools {
 		for (const image of imageSetManifest.images) {
 
 			const fullPath = path.resolve(this.options.baseDirectory, image.path);
-			const s3Path = `${s3BasePath}/${image.name}`;
+			const s3Path = `${s3BasePath}/${image.name}-${image.hash}`;
 			const s3PathExt = `${s3Path}.${image.extension}`;
 			const s3Config = {
 				ACL: 'public-read',

--- a/test/integration/cli-build-manifest.test.js
+++ b/test/integration/cli-build-manifest.test.js
@@ -36,8 +36,6 @@ describe('oist build-manifest', function() {
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
-			version: '0.0.0',
-			'host': 'https://www.ft.com',
 			sourceDirectory: 'src',
 			scheme: 'noscheme',
 			images: [
@@ -45,7 +43,8 @@ describe('oist build-manifest', function() {
 					name: 'example',
 					extension: 'png',
 					path: 'src/example.png',
-					hash: '923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'
+					hash: '923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda',
+					url: 'https://www.ft.com/noscheme/v0/example-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'
 				}
 			]
 		});
@@ -123,8 +122,6 @@ describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory oist build-manifest', functio
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
-			version: '0.0.0',
-			'host': 'https://www.ft.com',
 			sourceDirectory: 'is-a-directory',
 			scheme: 'noscheme',
 			images: []
@@ -164,8 +161,6 @@ describe('oist build-manifest --scheme test-scheme', function() {
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
-			version: '0.0.0',
-			'host': 'https://www.ft.com',
 			sourceDirectory: 'src',
 			scheme: 'test-scheme',
 			images: []
@@ -206,8 +201,6 @@ describe('IMAGESET_SCHEME=test-scheme oist build-manifest', function() {
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
-			version: '0.0.0',
-			'host': 'https://www.ft.com',
 			sourceDirectory: 'src',
 			scheme: 'test-scheme',
 			images: []

--- a/test/integration/cli-build-manifest.test.js
+++ b/test/integration/cli-build-manifest.test.js
@@ -36,6 +36,8 @@ describe('oist build-manifest', function() {
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
+			version: '0.0.0',
+			'host': 'https://www.ft.com',
 			sourceDirectory: 'src',
 			scheme: 'noscheme',
 			images: [
@@ -121,6 +123,8 @@ describe('IMAGESET_SOURCE_DIRECTORY=is-a-directory oist build-manifest', functio
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
+			version: '0.0.0',
+			'host': 'https://www.ft.com',
 			sourceDirectory: 'is-a-directory',
 			scheme: 'noscheme',
 			images: []
@@ -160,6 +164,8 @@ describe('oist build-manifest --scheme test-scheme', function() {
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
+			version: '0.0.0',
+			'host': 'https://www.ft.com',
 			sourceDirectory: 'src',
 			scheme: 'test-scheme',
 			images: []
@@ -200,6 +206,8 @@ describe('IMAGESET_SCHEME=test-scheme oist build-manifest', function() {
 		let manifestJson;
 		assert.doesNotThrow(() => manifestJson = JSON.parse(manifestContents));
 		assert.deepEqual(manifestJson, {
+			version: '0.0.0',
+			'host': 'https://www.ft.com',
 			sourceDirectory: 'src',
 			scheme: 'test-scheme',
 			images: []

--- a/test/integration/cli-publish-s3.test.js
+++ b/test/integration/cli-publish-s3.test.js
@@ -78,11 +78,11 @@ describe('oist publish-s3', function() {
 
 		it('outputs a success message', function() {
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1.png"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png"/i);
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2.jpg"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg"/i);
 		});
 
 		it('exits with a code of 0', function() {
@@ -92,10 +92,10 @@ describe('oist publish-s3', function() {
 		it('publishes the images to S3 under the expected keys', function() {
 			const s3 = createS3Instance();
 			return Promise.all([
-				s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg'}).promise()
 			]).then(data => {
 				assert.strictEqual(data[0].ContentType, 'image/png');
 				assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
@@ -138,11 +138,11 @@ describe('oist publish-s3', function() {
 
 		it('outputs a success message', function() {
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1.png"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "noscheme\/v0\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png"/i);
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2.jpg"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "noscheme\/v0\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg"/i);
 		});
 
 		it('exits with a code of 0', function() {
@@ -152,10 +152,10 @@ describe('oist publish-s3', function() {
 		it('publishes the images to S3 under the expected keys', function() {
 			const s3 = createS3Instance();
 			return Promise.all([
-				s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg'}).promise()
 			]).then(data => {
 				assert.strictEqual(data[0].ContentType, 'image/png');
 				assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
@@ -199,11 +199,11 @@ describe('oist publish-s3', function() {
 
 		it('outputs a success message', function() {
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1.png"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png"/i);
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2.jpg"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg"/i);
 		});
 
 		it('exits with a code of 0', function() {
@@ -213,10 +213,10 @@ describe('oist publish-s3', function() {
 		it('publishes the images to S3 under the expected keys', function() {
 			const s3 = createS3Instance();
 			return Promise.all([
-				s3.getObject({Key: 'test-scheme/v4/example1'}).promise(),
-				s3.getObject({Key: 'test-scheme/v4/example1.png'}).promise(),
-				s3.getObject({Key: 'test-scheme/v4/example2'}).promise(),
-				s3.getObject({Key: 'test-scheme/v4/example2.jpg'}).promise()
+				s3.getObject({Key: 'test-scheme/v4/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'}).promise(),
+				s3.getObject({Key: 'test-scheme/v4/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png'}).promise(),
+				s3.getObject({Key: 'test-scheme/v4/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5'}).promise(),
+				s3.getObject({Key: 'test-scheme/v4/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg'}).promise()
 			]).then(data => {
 				assert.strictEqual(data[0].ContentType, 'image/png');
 				assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
@@ -261,11 +261,11 @@ describe('oist publish-s3', function() {
 
 		it('outputs a success message', function() {
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example1.png" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1.png"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example1.png" to s3 under "test-scheme\/v4\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png"/i);
 			assert.match(global.cliCall.lastResult.output, /publishing "src\/example2.jpg" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2"/i);
-			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2.jpg"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5"/i);
+			assert.match(global.cliCall.lastResult.output, /published "src\/example2.jpg" to s3 under "test-scheme\/v4\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg"/i);
 		});
 
 		it('exits with a code of 0', function() {
@@ -275,10 +275,10 @@ describe('oist publish-s3', function() {
 		it('publishes the images to S3 under the expected keys', function() {
 			const s3 = createS3Instance();
 			return Promise.all([
-				s3.getObject({Key: 'test-scheme/v4/example1'}).promise(),
-				s3.getObject({Key: 'test-scheme/v4/example1.png'}).promise(),
-				s3.getObject({Key: 'test-scheme/v4/example2'}).promise(),
-				s3.getObject({Key: 'test-scheme/v4/example2.jpg'}).promise()
+				s3.getObject({Key: 'test-scheme/v4/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'}).promise(),
+				s3.getObject({Key: 'test-scheme/v4/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png'}).promise(),
+				s3.getObject({Key: 'test-scheme/v4/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5'}).promise(),
+				s3.getObject({Key: 'test-scheme/v4/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg'}).promise()
 			]).then(data => {
 				assert.strictEqual(data[0].ContentType, 'image/png');
 				assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
@@ -321,9 +321,9 @@ describe('oist publish-s3', function() {
 
 		it('outputs a success message', function() {
 			assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example1.png" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
+			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example1.png" to s3 under "noscheme\/v0\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda"/i);
 			assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example2.jpg" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
+			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example2.jpg" to s3 under "noscheme\/v0\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5"/i);
 		});
 
 		it('exits with a code of 0', function() {
@@ -333,10 +333,10 @@ describe('oist publish-s3', function() {
 		it('publishes the images to S3 under the expected keys', function() {
 			const s3 = createS3Instance();
 			return Promise.all([
-				s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg'}).promise()
 			]).then(data => {
 				assert.strictEqual(data[0].ContentType, 'image/png');
 				assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');
@@ -380,9 +380,9 @@ describe('oist publish-s3', function() {
 
 		it('outputs a success message', function() {
 			assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example1.png" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example1.png" to s3 under "noscheme\/v0\/example1"/i);
+			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example1.png" to s3 under "noscheme\/v0\/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda"/i);
 			assert.match(global.cliCall.lastResult.output, /publishing "is-a-directory\/example2.jpg" to s3/i);
-			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example2.jpg" to s3 under "noscheme\/v0\/example2"/i);
+			assert.match(global.cliCall.lastResult.output, /published "is-a-directory\/example2.jpg" to s3 under "noscheme\/v0\/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5"/i);
 		});
 
 		it('exits with a code of 0', function() {
@@ -392,10 +392,10 @@ describe('oist publish-s3', function() {
 		it('publishes the images to S3 under the expected keys', function() {
 			const s3 = createS3Instance();
 			return Promise.all([
-				s3.getObject({Key: 'noscheme/v0/example1'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example1.png'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2'}).promise(),
-				s3.getObject({Key: 'noscheme/v0/example2.jpg'}).promise()
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example1-923d4b188453ddd83f5cc175a445805db10f129ba5fcb509a67369a3165c538604a00a0fc1b8cc4afc929c71a6be204128d398eeac24fdb395769db92a43adda.png'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5'}).promise(),
+				s3.getObject({Key: 'noscheme/v0/example2-50e86c00c0815c1bd1c92e157ab234eb9b4f1f816b63f48ef9f9633e3ab9749d73086516db5f29e43b15fb2d3dd4ce96f7949cd8906198c78f039f86f8f671a5.jpg'}).promise()
 			]).then(data => {
 				assert.strictEqual(data[0].ContentType, 'image/png');
 				assert.strictEqual(data[0].Body.toString(), 'not-really-a-png');

--- a/test/unit/lib/origami-image-set-tools.test.js
+++ b/test/unit/lib/origami-image-set-tools.test.js
@@ -206,38 +206,41 @@ describe('lib/origami-image-set-tools', function () {
 
 				it('resolves with an object that contains the image names', function () {
 					assert.deepEqual(resolvedValue, {
-						version: options.version,
-						host: options.host,
 						sourceDirectory: options.sourceDirectory,
 						scheme: options.scheme,
-						images: [{
-							name: 'image-1',
-							extension: 'jpg',
-							path: `${options.sourceDirectory}/image-1.jpg`,
-							hash: 'a',
-							previousHash: undefined
-						},
-						{
-							name: 'image-2',
-							extension: 'png',
-							path: `${options.sourceDirectory}/image-2.png`,
-							hash: 'a',
-							previousHash: undefined
-						},
-						{
-							name: 'image-3',
-							extension: 'svg',
-							path: `${options.sourceDirectory}/image-3.svg`,
-							hash: 'a',
-							previousHash: undefined
-						},
-						{
-							name: 'image-4',
-							extension: 'gif',
-							path: `${options.sourceDirectory}/image-4.gif`,
-							hash: 'a',
-							previousHash: undefined
-						}
+						images: [
+							{
+								name: 'image-1',
+								extension: 'jpg',
+								path: `${options.sourceDirectory}/image-1.jpg`,
+								hash: 'a',
+								url: 'https://origami.ft.com/mock-scheme/vundefined/image-1-a',
+								previousHash: undefined
+							},
+							{
+								name: 'image-2',
+								extension: 'png',
+								path: `${options.sourceDirectory}/image-2.png`,
+								hash: 'a',
+								url: 'https://origami.ft.com/mock-scheme/vundefined/image-2-a',
+								previousHash: undefined
+							},
+							{
+								name: 'image-3',
+								extension: 'svg',
+								path: `${options.sourceDirectory}/image-3.svg`,
+								hash: 'a',
+								url: 'https://origami.ft.com/mock-scheme/vundefined/image-3-a',
+								previousHash: undefined
+							},
+							{
+								name: 'image-4',
+								extension: 'gif',
+								path: `${options.sourceDirectory}/image-4.gif`,
+								hash: 'a',
+								url: 'https://origami.ft.com/mock-scheme/vundefined/image-4-a',
+								previousHash: undefined
+							}
 						]
 					});
 				});
@@ -247,8 +250,6 @@ describe('lib/origami-image-set-tools', function () {
 
 					beforeEach(function () {
 						instance.readImageSetManifest = () => Promise.resolve({
-							version: options.version,
-							host: options.host,
 							sourceDirectory: options.sourceDirectory,
 							scheme: options.scheme,
 							images: [{
@@ -301,8 +302,6 @@ describe('lib/origami-image-set-tools', function () {
 
 					it('resolves with an object that contains the image names', function () {
 						assert.deepEqual(resolvedValue, {
-							version: options.version,
-							host: options.host,
 							sourceDirectory: options.sourceDirectory,
 							scheme: options.scheme,
 							images: [{
@@ -310,28 +309,32 @@ describe('lib/origami-image-set-tools', function () {
 								extension: 'jpg',
 								path: `${options.sourceDirectory}/image-1.jpg`,
 								hash: 'b',
-								previousHash: 'a'
+								previousHash: 'a',
+								'url': 'https://origami.ft.com/mock-scheme/vundefined/image-1-b'
 							},
 							{
 								name: 'image-2',
 								extension: 'png',
 								path: `${options.sourceDirectory}/image-2.png`,
 								hash: 'b',
-								previousHash: 'a'
+								previousHash: 'a',
+								'url': 'https://origami.ft.com/mock-scheme/vundefined/image-2-b'
 							},
 							{
 								name: 'image-3',
 								extension: 'svg',
 								path: `${options.sourceDirectory}/image-3.svg`,
 								hash: 'b',
-								previousHash: 'a'
+								previousHash: 'a',
+								'url': 'https://origami.ft.com/mock-scheme/vundefined/image-3-b'
 							},
 							{
 								name: 'image-4',
 								extension: 'gif',
 								path: `${options.sourceDirectory}/image-4.gif`,
 								hash: 'b',
-								previousHash: 'a'
+								previousHash: 'a',
+								'url': 'https://origami.ft.com/mock-scheme/vundefined/image-4-b'
 							}
 							]
 						});

--- a/test/unit/lib/origami-image-set-tools.test.js
+++ b/test/unit/lib/origami-image-set-tools.test.js
@@ -664,7 +664,7 @@ describe('lib/origami-image-set-tools', function () {
 						}
 						]
 					};
-					instance.readImageSetManifest = sinon.stub().resolves(imageSetManifest);
+					instance.buildImageSetManifest = sinon.stub().resolves(imageSetManifest);
 
 					mime.lookup.returns('mock-mimetype');
 
@@ -696,8 +696,8 @@ describe('lib/origami-image-set-tools', function () {
 					});
 				});
 
-				it('reads an image set manifest', function () {
-					assert.calledOnce(instance.readImageSetManifest);
+				it('builds an image set manifest', function () {
+					assert.calledOnce(instance.buildImageSetManifest);
 				});
 
 				it('logs that each image is being published', function () {

--- a/test/unit/lib/origami-image-set-tools.test.js
+++ b/test/unit/lib/origami-image-set-tools.test.js
@@ -634,17 +634,23 @@ describe('lib/origami-image-set-tools', function () {
 						images: [{
 							name: 'foo-image',
 							extension: 'png',
-							path: 'src/foo-image.png'
+							path: 'src/foo-image.png',
+							previousHash: 'a',
+							hash: 'b'
 						},
 						{
 							name: 'bar-image',
 							extension: 'jpg',
-							path: 'src/bar-image.jpg'
+							path: 'src/bar-image.jpg',
+							previousHash: 'c',
+							hash: 'd'
 						},
 						{
 							name: 'baz-image',
 							extension: 'svg',
-							path: 'src/baz-image.svg'
+							path: 'src/baz-image.svg',
+							previousHash: 'e',
+							hash: 'f'
 						}
 						]
 					};
@@ -711,47 +717,47 @@ describe('lib/origami-image-set-tools', function () {
 						ACL: 'public-read',
 						Body: fileStream,
 						ContentType: 'mock-mimetype',
-						Key: 'mock-scheme/v9/foo-image'
+						Key: 'mock-scheme/v9/foo-image-b'
 					});
 					assert.calledWith(AWS.S3.mockInstance.upload, {
 						ACL: 'public-read',
 						Body: fileStream,
 						ContentType: 'mock-mimetype',
-						Key: 'mock-scheme/v9/foo-image.png'
+						Key: 'mock-scheme/v9/foo-image-b.png'
 					});
 					assert.calledWith(AWS.S3.mockInstance.upload, {
 						ACL: 'public-read',
 						Body: fileStream,
 						ContentType: 'mock-mimetype',
-						Key: 'mock-scheme/v9/bar-image'
+						Key: 'mock-scheme/v9/bar-image-d'
 					});
 					assert.calledWith(AWS.S3.mockInstance.upload, {
 						ACL: 'public-read',
 						Body: fileStream,
 						ContentType: 'mock-mimetype',
-						Key: 'mock-scheme/v9/bar-image.jpg'
+						Key: 'mock-scheme/v9/bar-image-d.jpg'
 					});
 					assert.calledWith(AWS.S3.mockInstance.upload, {
 						ACL: 'public-read',
 						Body: fileStream,
 						ContentType: 'mock-mimetype',
-						Key: 'mock-scheme/v9/baz-image'
+						Key: 'mock-scheme/v9/baz-image-f'
 					});
 					assert.calledWith(AWS.S3.mockInstance.upload, {
 						ACL: 'public-read',
 						Body: fileStream,
 						ContentType: 'mock-mimetype',
-						Key: 'mock-scheme/v9/baz-image.svg'
+						Key: 'mock-scheme/v9/baz-image-f.svg'
 					});
 				});
 
 				it('logs that each image has been published', function () {
-					assert.calledWithExactly(log.info, '✔︎ Published "src/foo-image.png" to S3 under "mock-scheme/v9/foo-image"');
-					assert.calledWithExactly(log.info, '✔︎ Published "src/foo-image.png" to S3 under "mock-scheme/v9/foo-image.png"');
-					assert.calledWithExactly(log.info, '✔︎ Published "src/bar-image.jpg" to S3 under "mock-scheme/v9/bar-image"');
-					assert.calledWithExactly(log.info, '✔︎ Published "src/bar-image.jpg" to S3 under "mock-scheme/v9/bar-image.jpg"');
-					assert.calledWithExactly(log.info, '✔︎ Published "src/baz-image.svg" to S3 under "mock-scheme/v9/baz-image"');
-					assert.calledWithExactly(log.info, '✔︎ Published "src/baz-image.svg" to S3 under "mock-scheme/v9/baz-image.svg"');
+					assert.calledWithExactly(log.info, '✔︎ Published "src/foo-image.png" to S3 under "mock-scheme/v9/foo-image-b"');
+					assert.calledWithExactly(log.info, '✔︎ Published "src/foo-image.png" to S3 under "mock-scheme/v9/foo-image-b.png"');
+					assert.calledWithExactly(log.info, '✔︎ Published "src/bar-image.jpg" to S3 under "mock-scheme/v9/bar-image-d"');
+					assert.calledWithExactly(log.info, '✔︎ Published "src/bar-image.jpg" to S3 under "mock-scheme/v9/bar-image-d.jpg"');
+					assert.calledWithExactly(log.info, '✔︎ Published "src/baz-image.svg" to S3 under "mock-scheme/v9/baz-image-f"');
+					assert.calledWithExactly(log.info, '✔︎ Published "src/baz-image.svg" to S3 under "mock-scheme/v9/baz-image-f.svg"');
 				});
 
 				it('resolves with `undefined`', function () {

--- a/test/unit/lib/origami-image-set-tools.test.js
+++ b/test/unit/lib/origami-image-set-tools.test.js
@@ -127,6 +127,7 @@ describe('lib/origami-image-set-tools', function () {
 				awsAccessKey: 'mock-aws-key',
 				awsSecretKey: 'mock-aws-secret',
 				baseDirectory: 'mock-base-directory',
+				host: 'https://origami.ft.com',
 				imageServiceApiKey: 'mock-image-service-api-key',
 				imageServiceUrl: 'mock-image-service-url',
 				log: log,
@@ -205,6 +206,8 @@ describe('lib/origami-image-set-tools', function () {
 
 				it('resolves with an object that contains the image names', function () {
 					assert.deepEqual(resolvedValue, {
+						version: options.version,
+						host: options.host,
 						sourceDirectory: options.sourceDirectory,
 						scheme: options.scheme,
 						images: [{
@@ -244,6 +247,8 @@ describe('lib/origami-image-set-tools', function () {
 
 					beforeEach(function () {
 						instance.readImageSetManifest = () => Promise.resolve({
+							version: options.version,
+							host: options.host,
 							sourceDirectory: options.sourceDirectory,
 							scheme: options.scheme,
 							images: [{
@@ -296,6 +301,8 @@ describe('lib/origami-image-set-tools', function () {
 
 					it('resolves with an object that contains the image names', function () {
 						assert.deepEqual(resolvedValue, {
+							version: options.version,
+							host: options.host,
 							sourceDirectory: options.sourceDirectory,
 							scheme: options.scheme,
 							images: [{
@@ -654,7 +661,7 @@ describe('lib/origami-image-set-tools', function () {
 						}
 						]
 					};
-					instance.buildImageSetManifest = sinon.stub().resolves(imageSetManifest);
+					instance.readImageSetManifest = sinon.stub().resolves(imageSetManifest);
 
 					mime.lookup.returns('mock-mimetype');
 
@@ -686,8 +693,8 @@ describe('lib/origami-image-set-tools', function () {
 					});
 				});
 
-				it('builds an image set manifest', function () {
-					assert.calledOnce(instance.buildImageSetManifest);
+				it('reads an image set manifest', function () {
+					assert.calledOnce(instance.readImageSetManifest);
 				});
 
 				it('logs that each image is being published', function () {


### PR DESCRIPTION
having the version and host in the imageset file enables consumers of the imageset file to be able to create a full url for each image based solely on the information in the imageset file