### PR TITLE
mark the image-set-tools as dead since image-sets now live within the image-service itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Origami Image Set Tools
 =======================
 
+**No Longer used - ImageSets now live within the [Origami Image Service](Now that the image-set lives within the origami-image-service (Financial-Times/origami-image-service#763) - we no longer need this tool at all)**
+
 Tools for managing and uploading Origami image sets.
 
 [![NPM version](https://img.shields.io/npm/v/@financial-times/origami-image-set-tools.svg)](https://www.npmjs.com/package/@financial-times/origami-image-set-tools)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Origami Image Set Tools
 =======================
 
-**No Longer used - ImageSets now live within the [Origami Image Service](Now that the image-set lives within the origami-image-service (Financial-Times/origami-image-service#763) - we no longer need this tool at all)**
+**No Longer used - ImageSets now live within the [Origami Image Service](Financial-Times/origami-image-service#763)**
 
 Tools for managing and uploading Origami image sets.
 

--- a/origami.json
+++ b/origami.json
@@ -6,7 +6,7 @@
 		"origami"
 	],
 	"support": "https://github.com/Financial-Times/origami-image-set-tools/issues",
-	"supportStatus": "active",
+	"supportStatus": "dead",
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"


### PR DESCRIPTION
The image-set-tools was needed to create the imageset.json manifest and to upload the images to the correct S3 buckets.

Now that the image-set lives within the origami-image-service (https://github.com/Financial-Times/origami-image-service/pull/763) - we no longer need this tool at all